### PR TITLE
Calendar spelling fix

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@
           </fieldset>
         </section>
 
-        <section class="calender"><h3><strong>Calender</strong></h3>
-          <div id="calender"><iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showDate=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=150&amp;wkst=1&amp;bgcolor=%23ffffff&amp;src=5lg2l2mtslka3or3b9g5sj9d40%40group.calendar.google.com&amp;color=%230F4B38&amp;ctz=Europe%2FLondon" style="border-width:0" frameborder="0" scrolling="no"></iframe>
+        <section class="calendar"><h3><strong>Calendar</strong></h3>
+          <div id="calendar"><iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showNav=0&amp;showDate=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;showTz=0&amp;mode=AGENDA&amp;height=150&amp;wkst=1&amp;bgcolor=%23ffffff&amp;src=5lg2l2mtslka3or3b9g5sj9d40%40group.calendar.google.com&amp;color=%230F4B38&amp;ctz=Europe%2FLondon" style="border-width:0" frameborder="0" scrolling="no"></iframe>
         </div></section>
       </div>
 </html>

--- a/style2.css
+++ b/style2.css
@@ -51,13 +51,13 @@ header{
 .g-recaptcha{
   width:70px;
 }
-.calender{
+.calendar{
   /*background-color: #8B1C62;*/
   font-weight: bold;
   grid-column: 2/3;
 }
 
-#calender{
+#calendar{
   margin:auto;
   width:400px;
   height:200px;


### PR DESCRIPTION
This hotfix corrects the spelling of the instances of 'calender' to 'calendar' (caps & non-caps) in index.html and CSS, for both the user interface and internally.